### PR TITLE
Added use nodes for override and collision guard

### DIFF
--- a/lib/tp_plus/nodes/use_node.rb
+++ b/lib/tp_plus/nodes/use_node.rb
@@ -14,7 +14,11 @@ module TPPlus
           "UTOOL_NUM=#{@value.eval(context)}"
         when "use_payload"
           "PAYLOAD[#{@value.eval(context)}]"
-        end
+        when "use_override"
+          "OVERRIDE=#{@value.eval(context)}"
+        when "use_colguard"
+          "COL GUARD ADJUST #{@value.eval(context)}"
+        end	
       end
     end
   end

--- a/lib/tp_plus/token.rb
+++ b/lib/tp_plus/token.rb
@@ -99,7 +99,9 @@ module TPPlus
         "set_skip_condition" => :SET_SKIP_CONDITION,
         "use_payload" => :FANUC_USE,
         "use_uframe" => :FANUC_USE,
-        "use_utool" => :FANUC_USE
+        "use_utool" => :FANUC_USE,		
+        "use_override" => :FANUC_USE,		
+        "use_colguard" => :FANUC_USE
       }
 
 


### PR DESCRIPTION
The new use nodes use_override and use_colguard can be used in the same way as use_utool and similar.